### PR TITLE
godef and guru fail with wrong cwd

### DIFF
--- a/Godef.py
+++ b/Godef.py
@@ -158,7 +158,7 @@ to install them.')
             try:
                 p = subprocess.Popen(args, stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE, env=self.env,
-                                     startupinfo=startupinfo)
+                                     startupinfo=startupinfo, cwd=os.path.dirname(filename))
                 output, stderr = p.communicate()
             except Exception as e:
                 print("[Godef]EXPT: %s fail: %s" % (d['mode'], e))


### PR DESCRIPTION
### go env
```
set GO111MODULE=on
set GOARCH=amd64
set GOBIN=
set GOCACHE=C:\Users\guoji\AppData\Local\go-build
set GOENV=C:\Users\guoji\AppData\Roaming\go\env
set GOEXE=.exe
set GOFLAGS=-mod=mod
set GOHOSTARCH=amd64
set GOHOSTOS=windows
set GOINSECURE=
set GOMODCACHE=C:\Users\guoji\go\pkg\mod
set GONOPROXY=
set GONOSUMDB=
set GOOS=windows
set GOPATH=C:\Users\guoji\go
set GOPRIVATE=
set GOPROXY=https://goproxy.io,direct
set GOROOT=C:\Program Files\Go
set GOSUMDB=sum.golang.org
set GOTMPDIR=
set GOTOOLDIR=C:\Program Files\Go\pkg\tool\windows_amd64
set GOVCS=
set GOVERSION=go1.16.5
set GCCGO=gccgo
set AR=ar
set CC=gcc
set CXX=g++
set CGO_ENABLED=1
set GOMOD=NUL
set CGO_CFLAGS=-g -O2
set CGO_CPPFLAGS=
set CGO_CXXFLAGS=-g -O2
set CGO_FFLAGS=-g -O2
set CGO_LDFLAGS=-g -O2
set PKG_CONFIG=pkg-config
set GOGCCFLAGS=-m64 -mthreads -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=C:\Users\guoji\AppData\Local\Temp\go-build1531407127=/tmp/go-build -gno-record-gcc-switches
```

### error info
```
[Godef]ERROR: godef fail: godef: There must be at least one package that contains the file
[Godef]ERROR: guru fail: guru: cannot find module providing package k8s.io/kubernetes/cmd/kube-apiserver/app
```